### PR TITLE
chore: release only on demand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Release
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We may want to have few features and release it together instead of on every merge - it will easier to communicate, so let's build release on demand 