### PR TITLE
feat: cache dependencies between workflows

### DIFF
--- a/src/extensions/projectConfig.ts
+++ b/src/extensions/projectConfig.ts
@@ -56,10 +56,14 @@ module.exports = (toolbox: CycliToolbox) => {
       nodeVersionFileInDirectory(repoRoot)
 
     if (!file) {
-      filesystem.write(join(packageRoot, '.nvmrc'), DEFAULT_NODE_VERSION)
+      filesystem.write(join(packageRoot, '.nvmrc'), DEFAULT_NODE_VERSION + '\n')
 
       toolbox.interactive.warning(
-        'No node version file found. Created .nvmrc with default node version (v20.17.0).'
+        `No node version file found. Created .nvmrc with default node version (${DEFAULT_NODE_VERSION}).`
+      )
+
+      toolbox.furtherActions.push(
+        'Change node version in generated .nvmrc file if neccessary.'
       )
 
       return join(packageRoot, '.nvmrc')

--- a/src/extensions/projectConfig.ts
+++ b/src/extensions/projectConfig.ts
@@ -63,7 +63,10 @@ module.exports = (toolbox: CycliToolbox) => {
       )
 
       toolbox.furtherActions.push(
-        'Change node version in generated .nvmrc file if neccessary.'
+        [
+          `Couldn't retrieve your project's node version. Generated .nvmrc file with default node version (${DEFAULT_NODE_VERSION}).`,
+          'Please check if it matches your project and update if necessary.',
+        ].join(' ')
       )
 
       return join(packageRoot, '.nvmrc')

--- a/src/extensions/projectConfig.ts
+++ b/src/extensions/projectConfig.ts
@@ -1,6 +1,8 @@
-import { AppJson, CycliToolbox, PackageJson } from '../types'
+import { AppJson, CycliToolbox, PackageJson, ProjectContext } from '../types'
+import { join } from 'path'
 
 const APP_JSON_FILES = ['app.json', 'app.config.json']
+const DEFAULT_NODE_VERSION = 'v20.17.0'
 
 module.exports = (toolbox: CycliToolbox) => {
   const { filesystem } = toolbox
@@ -29,6 +31,43 @@ module.exports = (toolbox: CycliToolbox) => {
     return undefined
   }
 
+  const nodeVersionFileInDirectory = (dir: string): string | undefined => {
+    if (filesystem.exists(join(dir, '.nvmrc'))) {
+      return join(dir, '.nvmrc')
+    } else if (filesystem.exists(join('dir', '.node-version'))) {
+      return join(dir, '.node-version')
+    } else {
+      const packageJson = filesystem.read(join(dir, 'package.json'), 'json')
+      if (packageJson?.volta?.node || packageJson?.engines?.node) {
+        return join(dir, 'package.json')
+      }
+    }
+    return undefined
+  }
+
+  const nodeVersionFile = (context: ProjectContext): string => {
+    const { repoRoot, packageRoot } = context.path
+
+    // First, we look for node version in package root.
+    // If not found, we look for it in repository root (for monorepo support).
+    // If still not found, create .nvmrc in package root with default node version (v20.17.0).
+    const file =
+      nodeVersionFileInDirectory(packageRoot) ??
+      nodeVersionFileInDirectory(repoRoot)
+
+    if (!file) {
+      filesystem.write(join(packageRoot, '.nvmrc'), DEFAULT_NODE_VERSION)
+
+      toolbox.interactive.warning(
+        'No node version file found. Created .nvmrc with default node version (v20.17.0).'
+      )
+
+      return join(packageRoot, '.nvmrc')
+    }
+
+    return file
+  }
+
   const isExpo = (): boolean => {
     const appConfig = appJson()
 
@@ -55,6 +94,7 @@ module.exports = (toolbox: CycliToolbox) => {
     packageJson,
     appJsonFile,
     appJson,
+    nodeVersionFile,
     isExpo,
     getName,
   }
@@ -65,6 +105,7 @@ export interface ProjectConfigExtension {
     packageJson: () => PackageJson
     appJsonFile: () => string | undefined
     appJson: () => AppJson | undefined
+    nodeVersionFile: (context: ProjectContext) => string
     isExpo: () => boolean
     getName: () => string
   }

--- a/src/extensions/projectContext.ts
+++ b/src/extensions/projectContext.ts
@@ -16,7 +16,10 @@ module.exports = (toolbox: CycliToolbox) => {
 
     if (lockFiles.length == 0) {
       throw Error(
-        'No lock file found in repository root directory. Are you sure you are in a project directory?'
+        [
+          'No lock file found in repository root directory. Are you sure you are in a project directory?',
+          'Make sure you generated lock file by installing project dependencies.',
+        ].join('\n')
       )
     }
 

--- a/src/extensions/workflows.ts
+++ b/src/extensions/workflows.ts
@@ -30,10 +30,15 @@ module.exports = (toolbox: CycliToolbox) => {
       context.path.packageRoot
     )
 
+    const nodeVersionFile = context.path.relFromRepoRoot(
+      toolbox.projectConfig.nodeVersionFile(context)
+    )
+
     const workflowString = await toolbox.template.generate({
       template,
       props: {
         packageManager: context.packageManager,
+        nodeVersionFile,
         pathRelativeToRoot,
         ...props,
       },

--- a/src/templates/build-release/build-release-android.ejf
+++ b/src/templates/build-release/build-release-android.ejf
@@ -2,8 +2,8 @@
 const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
-  yarn: "yarn",
-  npm: "npm install"
+  yarn: "yarn install --immutable",
+  npm: "npm ci"
 }
 
 const build = {
@@ -48,6 +48,12 @@ jobs:
 
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
+
+      - name: 🌿 Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies
         run: <%= install[props.packageManager] %>

--- a/src/templates/build-release/build-release-android.ejf
+++ b/src/templates/build-release/build-release-android.ejf
@@ -49,10 +49,10 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies

--- a/src/templates/build-release/build-release-ios.ejf
+++ b/src/templates/build-release/build-release-ios.ejf
@@ -41,10 +41,10 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies

--- a/src/templates/build-release/build-release-ios.ejf
+++ b/src/templates/build-release/build-release-ios.ejf
@@ -2,8 +2,8 @@
 const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
-  yarn: "yarn",
-  npm: "npm install"
+  yarn: "yarn install --immutable",
+  npm: "npm ci"
 }
 
 const build = {
@@ -40,6 +40,12 @@ jobs:
     steps:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
+
+      - name: 🌿 Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies
         run: <%= install[props.packageManager] %>

--- a/src/templates/detox/test-detox-android.ejf
+++ b/src/templates/detox/test-detox-android.ejf
@@ -39,10 +39,10 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies

--- a/src/templates/detox/test-detox-android.ejf
+++ b/src/templates/detox/test-detox-android.ejf
@@ -2,8 +2,8 @@
 const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
-  yarn: "yarn",
-  npm: "npm install"
+  yarn: "yarn install --immutable",
+  npm: "npm ci"
 }
 
 const runTests = {
@@ -38,6 +38,12 @@ jobs:
 
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
+
+      - name: 🌿 Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies
         run: <%= install[props.packageManager] %>

--- a/src/templates/detox/test-detox-ios.ejf
+++ b/src/templates/detox/test-detox-ios.ejf
@@ -2,8 +2,8 @@
 const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
-  yarn: "yarn",
-  npm: "npm install"
+  yarn: "yarn install --immutable",
+  npm: "npm ci"
 }
 
 const runTests = {
@@ -36,6 +36,12 @@ jobs:
 
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
+
+      - name: 🌿 Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies
         run: <%= install[props.packageManager] %>

--- a/src/templates/detox/test-detox-ios.ejf
+++ b/src/templates/detox/test-detox-ios.ejf
@@ -37,10 +37,10 @@ jobs:
       - name: 🏗 Checkout repository
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies

--- a/src/templates/eas/eas-update.ejf
+++ b/src/templates/eas/eas-update.ejf
@@ -31,10 +31,10 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: Λ Setup EAS

--- a/src/templates/eas/eas-update.ejf
+++ b/src/templates/eas/eas-update.ejf
@@ -2,8 +2,8 @@
 const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
-  yarn: "yarn",
-  npm: "npm install"
+  yarn: "yarn install --immutable",
+  npm: "npm ci"
 }
 %>
 
@@ -27,11 +27,17 @@ jobs:
             echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
             exit 1
           fi
-
+      
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
 
-      - name: ⚙️ Setup EAS
+      - name: 🌿 Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '<%= props.packageManager %>'
+
+      - name: Λ Setup EAS
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest

--- a/src/templates/jest/jest.ejf
+++ b/src/templates/jest/jest.ejf
@@ -2,8 +2,8 @@
 const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
-  yarn: "yarn",
-  npm: "npm install"
+  yarn: "yarn install --immutable",
+  npm: "npm ci"
 }
 
 const run = {
@@ -20,15 +20,21 @@ on:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
 jobs:
-   jest:
-      name: Jest
-      runs-on: ubuntu-latest
-      steps:
-         - name: 🏗 Setup repo
+  jest:
+    name: Jest
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
            uses: actions/checkout@v4
 
-         - name: 📦 Install dependencies
-           run: <%= install[props.packageManager] %>
+      - name: 🌿 Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '<%= props.packageManager %>'
 
-         - name: 🎭 Run Jest
-           run: <%= run[props.packageManager] %>
+      - name: 📦 Install dependencies
+        run: <%= install[props.packageManager] %>
+
+      - name: 🎭 Run Jest
+        run: <%= run[props.packageManager] %>

--- a/src/templates/jest/jest.ejf
+++ b/src/templates/jest/jest.ejf
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-           uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies

--- a/src/templates/lint/lint.ejf
+++ b/src/templates/lint/lint.ejf
@@ -27,10 +27,10 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies

--- a/src/templates/lint/lint.ejf
+++ b/src/templates/lint/lint.ejf
@@ -2,8 +2,8 @@
 const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
-  yarn: "yarn",
-  npm: "npm install"
+  yarn: "yarn install --immutable",
+  npm: "npm ci"
 }
 
 const run = {
@@ -20,15 +20,21 @@ on:
       - ${props.pathRelativeToRoot}/**` : "" %>
  
 jobs:
-   eslint:
-      name: ESLint
-      runs-on: ubuntu-latest
-      steps:
-         - name: 🏗 Setup repo
-           uses: actions/checkout@v4
+  eslint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v4
 
-         - name: 📦 Install dependencies
-           run: <%= install[props.packageManager] %>
+      - name: 🌿 Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '<%= props.packageManager %>'
 
-         - name: 🤓 Run ESLint
-           run: <%= run[props.packageManager] %>
+      - name: 📦 Install dependencies
+        run: <%= install[props.packageManager] %>
+
+      - name: 🤓 Run ESLint
+        run: <%= run[props.packageManager] %>

--- a/src/templates/prettier/prettier.ejf
+++ b/src/templates/prettier/prettier.ejf
@@ -2,8 +2,8 @@
 const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
-  yarn: "yarn",
-  npm: "npm install"
+  yarn: "yarn install --immutable",
+  npm: "npm ci"
 }
 
 const run = {
@@ -20,15 +20,21 @@ on:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
 jobs:
-   prettier-check:
-      name: Prettier check
-      runs-on: ubuntu-latest
-      steps:
-         - name: 🏗 Setup repo
-           uses: actions/checkout@v4
+  prettier-check:
+    name: Prettier check
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v4
 
-         - name: 📦 Install dependencies
-           run: <%= install[props.packageManager] %>
+      - name: 🌿 Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '<%= props.packageManager %>'
 
-         - name: ✨ Run Prettier check
-           run: <%= run[props.packageManager] %>
+      - name: 📦 Install dependencies
+        run: <%= install[props.packageManager] %>
+
+      - name: ✨ Run Prettier check
+        run: <%= run[props.packageManager] %>

--- a/src/templates/prettier/prettier.ejf
+++ b/src/templates/prettier/prettier.ejf
@@ -27,10 +27,10 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies

--- a/src/templates/typescript/typescript.ejf
+++ b/src/templates/typescript/typescript.ejf
@@ -27,10 +27,10 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4
 
-      - name: 🌿 Setup Node 20
+      - name: 🌿 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '<%= props.nodeVersionFile %>'
           cache: '<%= props.packageManager %>'
 
       - name: 📦 Install dependencies

--- a/src/templates/typescript/typescript.ejf
+++ b/src/templates/typescript/typescript.ejf
@@ -2,8 +2,8 @@
 const isMonorepo = props.pathRelativeToRoot !== '.'
 
 const install = {
-  yarn: "yarn",
-  npm: "npm install"
+  yarn: "yarn install --immutable",
+  npm: "npm ci"
 }
 
 const run = {
@@ -20,15 +20,21 @@ on:
       - ${props.pathRelativeToRoot}/**` : "" %>
 
 jobs:
-   typescript-check:
-      name: Typescript check
-      runs-on: ubuntu-latest
-      steps:
-         - name: 🏗 Setup repo
-           uses: actions/checkout@v4
+  typescript-check:
+    name: Typescript check
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v4
 
-         - name: 📦 Install dependencies
-           run: <%= install[props.packageManager] %>
+      - name: 🌿 Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '<%= props.packageManager %>'
 
-         - name: 🔍 Run Typescript check
-           run: <%= run[props.packageManager] %>
+      - name: 📦 Install dependencies
+        run: <%= install[props.packageManager] %>
+
+      - name: 🔍 Run Typescript check
+        run: <%= run[props.packageManager] %>

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,12 @@ export interface PackageJson {
   jest?: unknown
   prettier?: unknown
   workspaces?: string[]
+  engines?: {
+    node?: string
+  }
+  volta?: {
+    node?: string
+  }
 }
 
 export type LockFile = keyof typeof LOCK_FILE_TO_MANAGER


### PR DESCRIPTION
Resolves #93 

## Changes

- add `Make sure you generated lock file by installing project dependencies.` message to error when lock file is not detected
- find node version file `.nvmrc`/`.node-version`/`package.json` and pass its path to workflows to use in `setup node` action (create `.nvmrc.` with node `v20.17.0` if no file found)
- add 'setup node' action in all workflows to cache yarn/npm dependencies and fix node version
- change installation scripts to `npm ci` and `yarn install --immutable` for consistent runs
- fix some indentation problems in workflow templates