### PR TITLE
fix: install typescript in eslint recipe

### DIFF
--- a/src/recipes/lint.ts
+++ b/src/recipes/lint.ts
@@ -24,6 +24,7 @@ const execute = async (
   // eslint@9 introduces new configuration format that is not supported by widely used plugins yet,
   // so we stick to ^8 for now.
   await toolbox.dependencies.addDev('eslint', context, { version: '^8' })
+  await toolbox.dependencies.addDev('typescript', context)
   await toolbox.dependencies.addDev('@react-native/eslint-config', context)
 
   const withPrettier =


### PR DESCRIPTION
Fixes the following error when running eslint:

```
ESLint: 8.57.0

Error: Failed to load parser '@typescript-eslint/parser' declared in '.eslintrc.json » @react-native/eslint-config#overrides[2]': Cannot find module 'typescript'
Require stack:
- /home/runner/work/rn-setup-ci-yarn-flat/rn-setup-ci-yarn-flat/node_modules/@typescript-eslint/typescript-estree/dist/convert.js
- /home/runner/work/rn-setup-ci-yarn-flat/rn-setup-ci-yarn-flat/node_modules/@typescript-eslint/typescript-estree/dist/ast-converter.js
- /home/runner/work/rn-setup-ci-yarn-flat/rn-setup-ci-yarn-flat/node_modules/@typescript-eslint/typescript-estree/dist/parser.js
- /home/runner/work/rn-setup-ci-yarn-flat/rn-setup-ci-yarn-flat/node_modules/@typescript-eslint/typescript-estree/dist/index.js
- /home/runner/work/rn-setup-ci-yarn-flat/rn-setup-ci-yarn-flat/node_modules/@typescript-eslint/parser/dist/parser.js
- /home/runner/work/rn-setup-ci-yarn-flat/rn-setup-ci-yarn-flat/node_modules/@typescript-eslint/parser/dist/index.js
- /home/runner/work/rn-setup-ci-yarn-flat/rn-setup-ci-yarn-flat/node_modules/@eslint/eslintrc/dist/eslintrc.cjs
    at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Module._load (node:internal/modules/cjs/loader:1051:27)
    at Module.require (node:internal/modules/cjs/loader:1311:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/home/runner/work/rn-setup-ci-yarn-flat/rn-setup-ci-yarn-flat/node_modules/@typescript-eslint/typescript-estree/dist/convert.js:36:25)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Module.require (node:internal/modules/cjs/loader:1311:19)
Error: Process completed with exit code 2.
```